### PR TITLE
ServiceクラスのPatch処理内容訂正と単体テスト実装

### DIFF
--- a/src/main/java/com/user/stock/service/StockServiceImpl.java
+++ b/src/main/java/com/user/stock/service/StockServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -50,22 +51,22 @@ public class StockServiceImpl implements StockService {
                 .orElseThrow(() -> new StockNotFoundException("Stock not found:" + symbol));
 
         // シンボルが null でない場合、新しいシンボルで更新
-        if (stockRequest.getSymbol() != null) {
+        if (Objects.nonNull(stockRequest.getSymbol())) {
             existingStock.setSymbol(stockRequest.getSymbol());
         }
 
         // 会社名が null でない場合、新しい会社名で更新
-        if (stockRequest.getCompanyName() != null) {
+        if (Objects.nonNull(stockRequest.getCompanyName())) {
             existingStock.setCompanyName(stockRequest.getCompanyName());
         }
 
         // 数量が null でない場合、新しい数量で更新
-        if (stockRequest.getQuantity() != null) {
+        if (Objects.nonNull(stockRequest.getQuantity())) {
             existingStock.setQuantity(stockRequest.getQuantity());
         }
 
         // 価格が null でない場合、新しい価格で更新
-        if (stockRequest.getPrice() != null) {
+        if (Objects.nonNull(stockRequest.getPrice())) {
             existingStock.setPrice(stockRequest.getPrice());
         }
 

--- a/src/main/java/com/user/stock/service/StockServiceImpl.java
+++ b/src/main/java/com/user/stock/service/StockServiceImpl.java
@@ -46,12 +46,28 @@ public class StockServiceImpl implements StockService {
 
     @Override
     public Stock updateStock(Integer symbol, StockRequest stockRequest) {
-        Stock existingStock = this.stockMapper.findStockBySymbol(symbol).orElseThrow(() -> new StockNotFoundException("Stock not found:" + symbol));
+        Stock existingStock = this.stockMapper.findStockBySymbol(symbol)
+                .orElseThrow(() -> new StockNotFoundException("Stock not found:" + symbol));
 
-        existingStock.setSymbol(stockRequest.getSymbol());
-        existingStock.setCompanyName(stockRequest.getCompanyName());
-        existingStock.setQuantity(stockRequest.getQuantity());
-        existingStock.setPrice(stockRequest.getPrice());
+        // シンボルが null でない場合、新しいシンボルで更新
+        if (stockRequest.getSymbol() != null) {
+            existingStock.setSymbol(stockRequest.getSymbol());
+        }
+
+        // 会社名が null でない場合、新しい会社名で更新
+        if (stockRequest.getCompanyName() != null) {
+            existingStock.setCompanyName(stockRequest.getCompanyName());
+        }
+
+        // 数量が null でない場合、新しい数量で更新
+        if (stockRequest.getQuantity() != null) {
+            existingStock.setQuantity(stockRequest.getQuantity());
+        }
+
+        // 価格が null でない場合、新しい価格で更新
+        if (stockRequest.getPrice() != null) {
+            existingStock.setPrice(stockRequest.getPrice());
+        }
 
         stockMapper.updateStock(existingStock);
         return existingStock;

--- a/src/test/java/com/user/stock/service/StockServiceImplTest.java
+++ b/src/test/java/com/user/stock/service/StockServiceImplTest.java
@@ -81,39 +81,24 @@ public class StockServiceImplTest {
     }
 
     @Test
-    public void 株式の数量だけが更新できること() {
+    public void パラメーターがnullの場合は更新されないことを確認する() {
+        // Mockの設定
         doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
 
-        StockRequest stockRequest = new StockRequest(1, 7203, "トヨタ自動車", 200, 2640);
+        // テストデータ（nullを含む）
+        StockRequest stockRequest = new StockRequest(1, null, null, null, null); // シンボル以外がnullの場合
         Stock actual = stockServiceImpl.updateStock(7203, stockRequest);
-        Stock stock = new Stock(1, 7203, "トヨタ自動車", 200, 2640);
-        assertThat(actual).isEqualTo(stock);
-        verify(stockMapper).findStockBySymbol(7203);
-        verify(stockMapper).updateStock(stock);
-    }
 
-    @Test
-    public void 株式の金額だけが更新できること() {
-        doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
+        // 検証
+        assertThat(actual).isNotNull();
+        verify(stockMapper, times(1)).updateStock(any(Stock.class)); // メソッドが1回呼び出されたことを検証
+        verify(stockMapper, times(1)).findStockBySymbol(7203);
 
-        StockRequest stockRequest = new StockRequest(1, 7203, "トヨタ自動車", 100, 3000);
-        Stock actual = stockServiceImpl.updateStock(7203, stockRequest);
-        Stock stock = new Stock(1, 7203, "トヨタ自動車", 100, 3000);
-        assertThat(actual).isEqualTo(stock);
-        verify(stockMapper).findStockBySymbol(7203);
-        verify(stockMapper).updateStock(stock);
-    }
-
-    @Test
-    public void 株式の数量と金額が更新できること() {
-        doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
-
-        StockRequest stockRequest = new StockRequest(1, 7203, "トヨタ自動車", 200, 3000);
-        Stock actual = stockServiceImpl.updateStock(7203, stockRequest);
-        Stock stock = new Stock(1, 7203, "トヨタ自動車", 200, 3000);
-        assertThat(actual).isEqualTo(stock);
-        verify(stockMapper).findStockBySymbol(7203);
-        verify(stockMapper).updateStock(stock);
+        // アサーション
+        assertThat(actual.getSymbol()).isEqualTo(7203);
+        assertThat(actual.getCompanyName()).isEqualTo("トヨタ自動車");
+        assertThat(actual.getQuantity()).isEqualTo(100);
+        assertThat(actual.getPrice()).isEqualTo(2640);
     }
 
     @Test

--- a/src/test/java/com/user/stock/service/StockServiceImplTest.java
+++ b/src/test/java/com/user/stock/service/StockServiceImplTest.java
@@ -107,7 +107,7 @@ public class StockServiceImplTest {
         doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
 
         // テストデータ（null以外の値を含む）
-        StockRequest stockRequest = new StockRequest(1, 7203, "トヨタ自動車", 150, 3000);
+        StockRequest stockRequest = new StockRequest(1, 8766, "東京海上", 150, 3000); // 異なる値を与える
         Stock actual = stockServiceImpl.updateStock(7203, stockRequest);
 
         // 検証
@@ -116,8 +116,8 @@ public class StockServiceImplTest {
         verify(stockMapper, times(1)).findStockBySymbol(7203);
 
         // アサーション
-        assertThat(actual.getSymbol()).isEqualTo(7203);
-        assertThat(actual.getCompanyName()).isEqualTo("トヨタ自動車");
+        assertThat(actual.getSymbol()).isEqualTo(8766);
+        assertThat(actual.getCompanyName()).isEqualTo("東京海上"); // 与えた値が反映されていることを確認
         assertThat(actual.getQuantity()).isEqualTo(150);
         assertThat(actual.getPrice()).isEqualTo(3000);
     }

--- a/src/test/java/com/user/stock/service/StockServiceImplTest.java
+++ b/src/test/java/com/user/stock/service/StockServiceImplTest.java
@@ -102,6 +102,27 @@ public class StockServiceImplTest {
     }
 
     @Test
+    public void パラメーターがnullでない場合は正しく更新されることを確認する() {
+        // Mockの設定
+        doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
+
+        // テストデータ（null以外の値を含む）
+        StockRequest stockRequest = new StockRequest(1, 7203, "トヨタ自動車", 150, 3000);
+        Stock actual = stockServiceImpl.updateStock(7203, stockRequest);
+
+        // 検証
+        assertThat(actual).isNotNull();
+        verify(stockMapper, times(1)).updateStock(any(Stock.class)); // メソッドが1回呼び出されたことを検証
+        verify(stockMapper, times(1)).findStockBySymbol(7203);
+
+        // アサーション
+        assertThat(actual.getSymbol()).isEqualTo(7203);
+        assertThat(actual.getCompanyName()).isEqualTo("トヨタ自動車");
+        assertThat(actual.getQuantity()).isEqualTo(150);
+        assertThat(actual.getPrice()).isEqualTo(3000);
+    }
+
+    @Test
     public void 存在しない株式の更新時にエラーが返されること() {
         // モックの設定: findStockBySymbolが存在しない株式を返すように設定
         when(stockMapper.findStockBySymbol(3863)).thenReturn(Optional.empty());

--- a/src/test/java/com/user/stock/service/StockServiceImplTest.java
+++ b/src/test/java/com/user/stock/service/StockServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.user.stock.service;
 
+import com.user.stock.controller.request.StockRequest;
 import com.user.stock.entity.Stock;
 import com.user.stock.exception.StockAlreadyExistsException;
 import com.user.stock.exception.StockNotFoundException;
@@ -19,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class UserServiceImplTest {
+public class StockServiceImplTest {
 
     @InjectMocks
     StockServiceImpl stockServiceImpl;
@@ -76,6 +77,53 @@ public class UserServiceImplTest {
         when(stockMapper.findStockBySymbol(7203)).thenReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640)));
         assertThrows(StockAlreadyExistsException.class, () -> {
             stockServiceImpl.insertStock(7203, "トヨタ自動車", 100, 2640);
+        });
+    }
+
+    @Test
+    public void 株式の数量だけが更新できること() {
+        doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
+
+        StockRequest stockRequest = new StockRequest(1, 7203, "トヨタ自動車", 200, 2640);
+        Stock actual = stockServiceImpl.updateStock(7203, stockRequest);
+        Stock stock = new Stock(1, 7203, "トヨタ自動車", 200, 2640);
+        assertThat(actual).isEqualTo(stock);
+        verify(stockMapper).findStockBySymbol(7203);
+        verify(stockMapper).updateStock(stock);
+    }
+
+    @Test
+    public void 株式の金額だけが更新できること() {
+        doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
+
+        StockRequest stockRequest = new StockRequest(1, 7203, "トヨタ自動車", 100, 3000);
+        Stock actual = stockServiceImpl.updateStock(7203, stockRequest);
+        Stock stock = new Stock(1, 7203, "トヨタ自動車", 100, 3000);
+        assertThat(actual).isEqualTo(stock);
+        verify(stockMapper).findStockBySymbol(7203);
+        verify(stockMapper).updateStock(stock);
+    }
+
+    @Test
+    public void 株式の数量と金額が更新できること() {
+        doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
+
+        StockRequest stockRequest = new StockRequest(1, 7203, "トヨタ自動車", 200, 3000);
+        Stock actual = stockServiceImpl.updateStock(7203, stockRequest);
+        Stock stock = new Stock(1, 7203, "トヨタ自動車", 200, 3000);
+        assertThat(actual).isEqualTo(stock);
+        verify(stockMapper).findStockBySymbol(7203);
+        verify(stockMapper).updateStock(stock);
+    }
+
+    @Test
+    public void 存在しない株式の更新時にエラーが返されること() {
+        // モックの設定: findStockBySymbolが存在しない株式を返すように設定
+        when(stockMapper.findStockBySymbol(3863)).thenReturn(Optional.empty());
+
+        // 期待される例外をアサート
+        assertThrows(StockNotFoundException.class, () -> {
+            stockServiceImpl.updateStock(3863, new StockRequest(1, 7203, "トヨタ自動車", 100, 2640));
         });
     }
 }


### PR DESCRIPTION
# 概要
1. StockServiceImplクラスのPatch処理のコードの訂正

***理由：下記のような現象が発生したため***
> ![スクリーン ショット 2024-01-15 に 午後7 08 31](https://github.com/KIKI0911/Stock_API/assets/148507850/8ad42e0e-75cb-43d9-89d3-5251f33fc2f6)

2. StockServiceImplクラスのPatch処理に対する単体テストを実施しました

## 内容
updateStock()メソッド、そのハンドリング処理に対する単体テストを実施しました。

## 単体テスト
### updateStock()メソッド
> ***[株式の数量だけが更新]***
![スクリーン ショット 2024-01-15 に 午後7 47 57](https://github.com/KIKI0911/Stock_API/assets/148507850/5b41e99f-7110-4dab-bf80-b4c640a62894)

>  ***[株式の金額だけが更新]***
![スクリーン ショット 2024-01-15 に 午後7 51 21](https://github.com/KIKI0911/Stock_API/assets/148507850/090536ea-4a8b-4bc1-a501-bdefab7fd680)

>  ***[株式の数量と金額の更新]***
![スクリーン ショット 2024-01-15 に 午後7 52 53](https://github.com/KIKI0911/Stock_API/assets/148507850/b5cc700c-d3b0-4989-abee-ff4e145c9e25)

## ハンドリング処理
![スクリーン ショット 2024-01-15 に 午後8 30 35](https://github.com/KIKI0911/Stock_API/assets/148507850/1f416579-cda2-4932-8167-b3a54b529816)
