### PR TITLE
delete処理の単体テスト実装

### DIFF
--- a/src/test/java/com/user/stock/service/StockServiceImplTest.java
+++ b/src/test/java/com/user/stock/service/StockServiceImplTest.java
@@ -132,4 +132,21 @@ public class StockServiceImplTest {
             stockServiceImpl.updateStock(3863, new StockRequest(1, 7203, "トヨタ自動車", 100, 2640));
         });
     }
+
+    @Test
+    public void 存在するシンボルを指定して削除できること() {
+        doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
+        stockServiceImpl.deleteStock(7203);
+        verify(stockMapper).findStockBySymbol(7203);
+        verify(stockMapper).deleteStock(7203);
+    }
+
+    @Test
+    public void 存在しないシンボルを指定した時にエラーが返ること() {
+        doReturn(Optional.empty()).when(stockMapper).findStockBySymbol(9999);
+        assertThrows(StockNotFoundException.class, () -> {
+            stockServiceImpl.deleteStock(9999);
+        }, "指定された株式が見つかりません");
+        verify(stockMapper).findStockBySymbol(9999);
+    }
 }

--- a/src/test/java/com/user/stock/service/StockServiceImplTest.java
+++ b/src/test/java/com/user/stock/service/StockServiceImplTest.java
@@ -135,6 +135,7 @@ public class StockServiceImplTest {
 
     @Test
     public void 存在するシンボルを指定して削除できること() {
+        doNothing().when(stockMapper).deleteStock(7203);
         doReturn(Optional.of(new Stock(1, 7203, "トヨタ自動車", 100, 2640))).when(stockMapper).findStockBySymbol(7203);
         stockServiceImpl.deleteStock(7203);
         verify(stockMapper).findStockBySymbol(7203);
@@ -148,5 +149,6 @@ public class StockServiceImplTest {
             stockServiceImpl.deleteStock(9999);
         }, "指定された株式が見つかりません");
         verify(stockMapper).findStockBySymbol(9999);
+        verify(stockMapper, never()).deleteStock(9999);
     }
 }


### PR DESCRIPTION
# 概要
[StockServiceImplクラス](https://github.com/KIKI0911/Stock_API/blob/main/src/main/java/com/user/stock/service/StockServiceImpl.java)のdelete処理に対する単体テストを実施しました

## 内容
deleteStock()メソッド、そのハンドリング処理に対する単体テストを実施しました。

## 単体テスト

deleteStock()メソッド

> ![スクリーン ショット 2024-01-19 に 午後9 17 18](https://github.com/KIKI0911/Stock_API/assets/148507850/f4519d98-a135-4de5-af28-d5d864db5f00)

### 例外処理
![スクリーン ショット 2024-01-19 に 午後9 17 57](https://github.com/KIKI0911/Stock_API/assets/148507850/492da224-eec4-4eee-bf16-52884925cfa4)
