### PR TITLE
Get処理のDBテスト実装

### DIFF
--- a/src/test/java/com/user/stock/mapper/StockMapperTest.java
+++ b/src/test/java/com/user/stock/mapper/StockMapperTest.java
@@ -1,0 +1,57 @@
+package com.user.stock.mapper;
+
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import com.user.stock.entity.Stock;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class StockMapperTest {
+
+    @Autowired
+    StockMapper stockMapper;
+
+    @Test
+    @DataSet(value = "datasets/stocks.yml")
+    @Transactional
+    void すべての株式が取得できること () {
+        List<Stock> stocks = stockMapper.findAllStocks();
+        assertThat(stocks)
+                .hasSize(4)
+                .contains(
+                        new Stock(1,7203,"トヨタ自動車",100, 2640),
+                        new Stock(2,9861, "吉野家ホールディングス",100, 3131),
+                        new Stock(3,3197, "スカイラークホールディングス", 100, 2059),
+                        new Stock(4,9101, "日本郵船",100, 4333));
+
+    }
+
+    @Test
+    @DataSet(value = "datasets/stocks.yml")
+    @Transactional
+    void 指定したシンボルの株式が取得できること() {
+        assertThat(stockMapper.findStockBySymbol(7203))
+                .contains(new Stock(1,7203,"トヨタ自動車",100, 2640));
+    }
+
+    @Test
+    @DataSet(value = "datasets/stocks.yml")
+    @Transactional
+    void 存在しないシンボルを指定する場合に空の情報を獲得すること() {
+        Optional<Stock> stock = stockMapper.findStockBySymbol(9999);
+        assertThat(stock).isEmpty();
+    }
+}

--- a/src/test/java/com/user/stock/mapper/StockMapperTest.java
+++ b/src/test/java/com/user/stock/mapper/StockMapperTest.java
@@ -31,7 +31,7 @@ public class StockMapperTest {
         List<Stock> stocks = stockMapper.findAllStocks();
         assertThat(stocks)
                 .hasSize(4)
-                .contains(
+                .containsExactlyInAnyOrder(
                         new Stock(1,7203,"トヨタ自動車",100, 2640),
                         new Stock(2,9861, "吉野家ホールディングス",100, 3131),
                         new Stock(3,3197, "スカイラークホールディングス", 100, 2059),

--- a/src/test/resources/datasets/stocks.yml
+++ b/src/test/resources/datasets/stocks.yml
@@ -1,0 +1,21 @@
+stocks:
+  - id: 1
+    symbol: 7203
+    companyName: "トヨタ自動車"
+    quantity: 100
+    price: 2640
+  - id: 2
+    symbol: 9861
+    companyName: "吉野家ホールディングス"
+    quantity: 100
+    price: 3131
+  - id: 3
+    symbol: 3197
+    companyName: "スカイラークホールディングス"
+    quantity: 100
+    price: 2059
+  - id: 4
+    symbol: 9101
+    companyName: "日本郵船"
+    quantity: 100
+    price: 4333

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: stock_list
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: "jdbc:mysql://localhost:3307/stock_list" # MySQLの場合
+  user: "user"
+  password: "password"


### PR DESCRIPTION
# 概要
Get処理のDBテストを実装しました。

## [内容]
1. 全件取得であるfindAllStocks()メソッド
2. findStockBySymbol()メソッド
3. 存在しないシンボルを指定する場合に空の情報を獲得することに対するDBテスト

## [DBテスト]
findAllStocks()
> ![スクリーンショット 2024-01-22 午後3 00 24](https://github.com/KIKI0911/Stock_API/assets/148507850/3e0c38c4-54b1-4242-b799-a503149c8fce)


findStockBySymbol()
> ![スクリーンショット 2024-01-22 午後2 59 45](https://github.com/KIKI0911/Stock_API/assets/148507850/4310bfb9-99b7-4001-be42-13f88a5c01ef)


存在しないシンボルを指定する場合に空の情報を獲得する
> ![スクリーンショット 2024-01-22 午後3 19 11](https://github.com/KIKI0911/Stock_API/assets/148507850/ef90cea9-0914-4962-8d2a-ad886fbc2fd3)
