### PR TITLE
Update処理に対する結合テストの実装

### DIFF
--- a/src/test/java/integrationtest/StockRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/StockRestApiIntegrationTest.java
@@ -159,6 +159,71 @@ public class StockRestApiIntegrationTest {
                 """, response, JSONCompareMode.STRICT);
     }
 
+
+    @Test
+    @DataSet(value = "datasets/stocks.yml")
+    @ExpectedDataSet(value = "datasets/updateTest.yml", ignoreCols = "id")
+    @Transactional
+    public void どれか一つだけnullではない場合その値だけが更新されていることを確認する() throws Exception {
+        Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.patch("/stocks/7203")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                                    "id": null,
+                                    "symbol": null,
+                                    "companyName": null,
+                                    "quantity": 500,
+                                    "price": null
+                                }
+                            """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString().contains("Stock updated"));
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/stocks/7203"))
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                    
+            {
+                       "id": 1,
+                       "symbol": 7203,
+                       "companyName": "トヨタ自動車",
+                       "quantity": 500,
+                       "price": 2640
+                   }
+            """, response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/stocks.yml")
+    @ExpectedDataSet(value = "datasets/stocks.yml", ignoreCols = "id")
+    @Transactional
+    public void 全ての値がnullの場合更新されないことを確認する() throws Exception {
+        Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.patch("/stocks/7203")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                                "id": null,
+                                "symbol": null,
+                                "companyName": null,
+                                "quantity": null,
+                                "price": null
+                            }
+                            """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString().contains("Stock updated"));
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/stocks/7203"))
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                    
+            {
+                       "id": 1,
+                       "symbol": 7203,
+                       "companyName": "トヨタ自動車",
+                       "quantity": 100,
+                       "price": 2640
+                   }
+            """, response, JSONCompareMode.STRICT);
+    }
+
     @Test
     @DataSet(value = "datasets/stocks.yml")
     @Transactional

--- a/src/test/java/integrationtest/StockRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/StockRestApiIntegrationTest.java
@@ -6,6 +6,7 @@ import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.user.stock.StockApplication;
 import com.user.stock.entity.Stock;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -124,5 +125,56 @@ public class StockRestApiIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/stocks").contentType(MediaType.APPLICATION_JSON).content(jason))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andReturn().getResponse().getContentAsString().contains("Stock already exists");
+    }
+
+    @Test
+    @DataSet(value = "datasets/stocks.yml")
+    @ExpectedDataSet(value = "datasets/updateStockTest.yml", ignoreCols = "id")
+    @Transactional
+    public void 存在する株式情報を更新するとステータスコード200が出力せれ更新されているか確認すること() throws Exception {
+        Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.patch("/stocks/7203")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                        "id": 1,
+                                        "symbol": 7203,
+                                        "companyName": "トヨタ自動車",
+                                        "quantity": 500,
+                                        "price": 3000
+                                    }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString().contains("Stock updated"));
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/stocks/7203"))
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                        
+                {
+                           "id": 1,
+                           "symbol": 7203,
+                           "companyName": "トヨタ自動車",
+                           "quantity": 500,
+                           "price": 3000
+                       }
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/stocks.yml")
+    @Transactional
+    public void 存在しない株式を更新するとステータスコード404とエラーメッセージが出力() throws Exception {
+        Assertions.assertTrue(mockMvc.perform(MockMvcRequestBuilders.patch("/stocks/2897")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                               "id" :5,
+                                               "symbol": 2897,
+                                               "companyName": "日清食品",
+                                               "quantity": 100,
+                                               "price": 5160
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString().contains("Not Found"));
     }
 }

--- a/src/test/resources/datasets/updateTest.yml
+++ b/src/test/resources/datasets/updateTest.yml
@@ -1,0 +1,21 @@
+stocks:
+  - id: 1
+    symbol: 7203
+    companyName: "トヨタ自動車"
+    quantity: 500
+    price: 2640
+  - id: 2
+    symbol: 9861
+    companyName: "吉野家ホールディングス"
+    quantity: 100
+    price: 3131
+  - id: 3
+    symbol: 3197
+    companyName: "スカイラークホールディングス"
+    quantity: 100
+    price: 2059
+  - id: 4
+    symbol: 9101
+    companyName: "日本郵船"
+    quantity: 100
+    price: 4333


### PR DESCRIPTION
# 概要
Update処理に対する結合テストの実装

## 内容
1. 存在する株式情報を更新するとステータスコード200が出力せれ更新されているか確認すること
2. 存在しない株式を更新するとステータスコード404とエラーメッセージが出力の確認

## 結合テスト
存在する株式情報を更新するとステータスコード200が出力せれ更新されているか確認すること
> ![スクリーン ショット 2024-02-05 に 午前8 41 01](https://github.com/KIKI0911/Stock_API/assets/148507850/b98da6b2-6b7b-40cb-aea3-7d9203ac77de)

存在しない株式を更新するとステータスコード404とエラーメッセージが出力の確認
> ![スクリーン ショット 2024-02-05 に 午前8 41 27](https://github.com/KIKI0911/Stock_API/assets/148507850/220efb39-6971-4b5c-ab3f-f56271514d12)
